### PR TITLE
Bring in JS files as part of Build, added settings.scss files

### DIFF
--- a/blueprints/ember-cli-foundation-6-sass/files/app/styles/app.scss
+++ b/blueprints/ember-cli-foundation-6-sass/files/app/styles/app.scss
@@ -1,2 +1,3 @@
+@import "settings";
 @import 'foundation';
 @include foundation-everything;

--- a/blueprints/ember-cli-foundation-6-sass/index.js
+++ b/blueprints/ember-cli-foundation-6-sass/index.js
@@ -1,12 +1,25 @@
+var fs          = require('fs');
+var path        = require('path');
+
 module.exports = {
   description: 'install ember-cli-foundation-6-sass into a typical project',
   normalizeEntityName: function() {},
 
   beforeInstall: function () {
-    return this.addBowerPackageToProject('foundation-sites', '~6.0.3');
+    return this.addBowerPackageToProject('foundation-sites', '~6.1.0');
   },
 
   afterInstall: function () {
-    return this.addPackageToProject('ember-cli-sass', '^5.1.0');
+    // Copy the _settings.scss file
+    var stylePath = path.join(process.cwd(), 'app', 'styles');
+    var foundationPath = path.join(process.cwd(), 'bower_components', 'foundation-sites', 'scss');
+    var settingsPath = path.join(foundationPath, 'settings', '_settings.scss');
+
+    fs.writeFileSync(path.join(stylePath, '_settings.scss'), fs.readFileSync(settingsPath));
+
+    return this.addPackagesToProject([
+      { name: 'ember-cli-sass', target: '^5.1.0' },
+      { name: 'broccoli-clean-css', target: '~1.1.0' }
+    ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,5 +11,21 @@ module.exports = {
     app.options.sassOptions = app.options.sassOptions || {};
     app.options.sassOptions.includePaths = app.options.sassOptions.includePaths || [];
     app.options.sassOptions.includePaths.push(foundationPath);
+
+    // Include the js paths
+    if (app.options.foundationJs) {
+      if ((typeof app.options.foundationJs == 'string') ||
+          (app.options.foundationJs instanceof String)) {
+        if (app.options.foundationJs === 'all') {
+          app.import(path.join(app.bowerDirectory, 'foundation-sites', 'dist', 'foundation.js'));
+        }
+      }
+      else if (options.foundationJs instanceof Array) {
+        options.foundationJs.forEach(function(componentName) {
+          var foundationJsPath = path.join(app.bowerDirectory, 'foundation-sites', 'js');
+          app.import(path.join(foundationJsPath, 'foundation.' + componentName + '.js'));
+        });
+      }
+    }
   }
 };


### PR DESCRIPTION
I added some code that shamelessly steals from the previous ember-cli-foundation-sass project. They had some neat build directives that allowed one to incorporate the foundation js files into the vendor.js file. They also had some code that utilizes broccoli-clean-css. I personally find this somewhat handy but that's only my 2 cents.

I also added code that moves the _sessings.scss file into the styles directory. It's really much more helpful for someone coming into foundation for the first time :)

Finally I bumped fondation to 6.1 since I like to live on the bleeding edge.