### PR TITLE
Make FoundationJS optional

### DIFF
--- a/addon/initializers/zf-widget.js
+++ b/addon/initializers/zf-widget.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 
 export function initialize(/* application */) {
   // application.inject('route', 'foo', 'service:foo');
-  Ember.$().foundation();
+  if (Ember.typeOf(Ember.$().foundation) === 'function') {
+    Ember.$().foundation();
+  }
 }
 
 export default {


### PR DESCRIPTION
Thanks for maintaining this repo! For the most part, it works great, but just ran into a bug. Currently, if I do not include foundation js, I get `Uncaught TypeError: _ember.default.$(...).foundation is not a function`. This PR checks that `foundation` is actually defined before trying to execute it.