### PR TITLE
Zf reveal destroy

### DIFF
--- a/addon/mixins/zf-widget.js
+++ b/addon/mixins/zf-widget.js
@@ -60,7 +60,7 @@ export default Ember.Mixin.create({
   /**
    * Handle destruction of component.
    */
-  shutdown: Ember.on('willDestoryElement', function() {
+  shutdown: Ember.on('willDestroyElement', function() {
     let ui = this.get('zfUi');
     if (Ember.isPresent(ui)) {
       let observers = this._observers;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -61,21 +61,16 @@
     <div class="small-12 large-expand columns">
       <h2>Reveal</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Esse aliquid, optio ab!</p>
-      {{#unless disableReveal}}
-        <p><a data-open="exampleModal">Click me for a modal</a></p>
-        {{#zf-reveal id="exampleModal" overlay=showDialogOverlay}}
-          <h1>Awesome. I Have It.</h1>
-          <p class="lead">Your couch. It is mine.</p>
-          <p>I'm a cool paragraph that lives inside of an even cooler modal. Wins!</p>
-          <button class="close-button" data-close aria-label="Close reveal" type="button">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        {{/zf-reveal}}
-      {{else}}
-        <p>Enable Reveal to test.</p>
-      {{/unless}}
+      <p><a data-open="exampleModal">Click me for a modal</a></p>
+      {{#zf-reveal id="exampleModal" overlay=showDialogOverlay}}
+        <h1>Awesome. I Have It.</h1>
+        <p class="lead">Your couch. It is mine.</p>
+        <p>I'm a cool paragraph that lives inside of an even cooler modal. Wins!</p>
+        <button class="close-button" data-close aria-label="Close reveal" type="button">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      {{/zf-reveal}}
       <p>{{input type="checkbox" name="showDialogOverlay" checked=showDialogOverlay}} Show Overlay</p>
-      <p>{{input type="checkbox" name="disableReveal" checked=disableReveal}} Disable Reveal</p>
     </div>
   </div>
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -61,16 +61,21 @@
     <div class="small-12 large-expand columns">
       <h2>Reveal</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Esse aliquid, optio ab!</p>
-      <p><a data-open="exampleModal">Click me for a modal</a></p>
-      {{#zf-reveal id="exampleModal" overlay=showDialogOverlay}}
-        <h1>Awesome. I Have It.</h1>
-        <p class="lead">Your couch. It is mine.</p>
-        <p>I'm a cool paragraph that lives inside of an even cooler modal. Wins!</p>
-        <button class="close-button" data-close aria-label="Close reveal" type="button">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      {{/zf-reveal}}
+      {{#unless disableReveal}}
+        <p><a data-open="exampleModal">Click me for a modal</a></p>
+        {{#zf-reveal id="exampleModal" overlay=showDialogOverlay}}
+          <h1>Awesome. I Have It.</h1>
+          <p class="lead">Your couch. It is mine.</p>
+          <p>I'm a cool paragraph that lives inside of an even cooler modal. Wins!</p>
+          <button class="close-button" data-close aria-label="Close reveal" type="button">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        {{/zf-reveal}}
+      {{else}}
+        <p>Enable Reveal to test.</p>
+      {{/unless}}
       <p>{{input type="checkbox" name="showDialogOverlay" checked=showDialogOverlay}} Show Overlay</p>
+      <p>{{input type="checkbox" name="disableReveal" checked=disableReveal}} Disable Reveal</p>
     </div>
   </div>
 

--- a/tests/integration/components/zf-reveal-test.js
+++ b/tests/integration/components/zf-reveal-test.js
@@ -1,0 +1,46 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import $ from 'jquery';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('zf-reveal', 'Integration | Component | zf reveal', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  // this.render(hbs`{{zf-reveal}}`);
+
+  // assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:" + EOL +
+  this.render(hbs`
+    {{#zf-reveal}}
+      template block text
+    {{/zf-reveal}}
+  `);
+
+  assert.equal($('.reveal-overlay').text().trim(), 'template block text');
+});
+
+test('it destroys the reveal-overlay', function(assert) {
+  assert.expect(2);
+
+  this.set('enableReveal', true);
+
+  this.render(hbs`
+    {{#if enableReveal}}
+      {{#zf-reveal}}
+        template block text
+      {{/zf-reveal}}
+    {{/if}}
+  `);
+
+  assert.equal($('.reveal-overlay').length, 1);
+
+  this.set('enableReveal', false);
+
+  assert.equal($('.reveal-overlay').length, 0);
+});

--- a/tests/integration/components/zf-slider-test.js
+++ b/tests/integration/components/zf-slider-test.js
@@ -12,8 +12,10 @@ test('it renders', function(assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
 
   // Template block usage:" + EOL +
+  let done = assert.async();
+
   this.render(hbs`
-    {{#zf-slider}}
+    {{#zf-slider }}
       <span class="slider-handle"  data-slider-handle role="slider" tabindex="1"></span>
       <span class="slider-fill" data-slider-fill></span>
       <input type="hidden">
@@ -21,5 +23,9 @@ test('it renders', function(assert) {
   `);
 
   assert.equal(this.$('.slider-handle').attr('role'), 'slider');
+
+  // changed.zf.slider is always executed, even if the slider hasn't actually moved.
+  // Use it to async complete this test.
+  this.$('.slider').on('changed.zf.slider', done);
 
 });


### PR DESCRIPTION
Fix `willDestroyElement` typo. It was preventing the `shutdown` method from being triggered.
Add zf-reveal test.
Fixed zf-slider test failure caused by `willDestroyElement`fix. The slider would ge removed from DOM at the end of the test and foundation's code triggers event handlers async in the Slider plugin, which is expecting the slider element and Slider instance to continue existing.

Fixes #26 