### PR TITLE
Use path.resolve to get the bower.json path. Fixes #28.

### DIFF
--- a/blueprints/ember-cli-foundation-6-sass/index.js
+++ b/blueprints/ember-cli-foundation-6-sass/index.js
@@ -1,6 +1,8 @@
+/* jshint node:true */
+
 var fs          = require('fs');
 var path        = require('path');
-var bower       = require('../../bower.json');
+var bower       = require(path.resolve(__dirname, '../../bower.json'));
 
 module.exports = {
   description: 'install ember-cli-foundation-6-sass into a typical project',


### PR DESCRIPTION
`require('../../bower.json');` couldn't be found. Use `path.resolve` to get the absolute path to prevent errors where require can't find the right file.