### PR TITLE
Remove bower.json from .npmconfig

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,5 @@ dist/
 .travis.yml
 .npmignore
 **/.gitkeep
-bower.json
 Brocfile.js
 testem.json


### PR DESCRIPTION
@acoustep Sorry, I thought I had fixed this, but this is the real fix. Apparently bower.json is still missing and it's expected to be part of the package when published to npm.

I missed this because I `npm link` the repo when testing, which of course had the bower.json file.