### PR TITLE
Update index file babel call to use plugins properly.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "foundation-sites": "^6.2.1",
+    "foundation-sites": "^6.2.4",
     "jquery": "~2.1.0",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"

--- a/index.js
+++ b/index.js
@@ -26,9 +26,21 @@ module.exports = {
       else if (options.foundationJs instanceof Array) {
         options.foundationJs.forEach(function(componentName) {
           var foundationJsPath = path.join(app.bowerDirectory, 'foundation-sites', 'js');
-          var es5code = babel.transformFileSync(path.join(foundationJsPath, 'foundation.' + componentName + '.js')).code;
+          var es5code = babel.transformFileSync(path.join(foundationJsPath, 'foundation.' + componentName + '.js'), {
+            'plugins': [
+              require.resolve('babel-plugin-transform-es2015-arrow-functions'),
+              require.resolve('babel-plugin-transform-es2015-block-scoped-functions'),
+              require.resolve('babel-plugin-transform-es2015-block-scoping'),
+              require.resolve('babel-plugin-transform-es2015-classes'),
+              require.resolve('babel-plugin-transform-es2015-destructuring'),
+              require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
+              require.resolve('babel-plugin-transform-es2015-parameters'),
+              require.resolve('babel-plugin-transform-es2015-shorthand-properties'),
+              require.resolve('babel-plugin-transform-es2015-spread'),
+              require.resolve('babel-plugin-transform-es2015-template-literals')
+            ]
+          }).code;
           var filenameAndPath = path.join(foundationJsPath, 'foundation.' + componentName + '.es5.js');
-
           fs.writeFileSync(filenameAndPath, es5code);
           app.import(filenameAndPath);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-foundation-6-sass",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Foundation 6 SASS package for Ember CLI",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "Mitch Stanley",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.18.2",
     "broccoli-asset-rev": "^2.2.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
@@ -46,6 +45,18 @@
     "ember-addon"
   ],
   "dependencies": {
+    "babel-core": "^6.20.0",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+    "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.18.0",
+    "babel-plugin-transform-es2015-classes": "^6.18.0",
+    "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
+    "babel-plugin-transform-es2015-parameters": "^6.18.0",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.18.0",
+    "babel-plugin-transform-es2015-spread": "^6.8.0",
+    "babel-plugin-transform-es2015-template-literals": "^6.8.0",
+    "babel-register": "^6.18.0",
     "ember-cli-htmlbars": "^1.0.2",
     "ember-cli-sass": "^5.1.0"
   },


### PR DESCRIPTION
- Also moves dependencies to package.json `dependencies`, not `devDependencies`

This should fix #35 and finish the work started in #34 (sorry it wasn't quite right the first time)