### PR TITLE
Support foundation sites 6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ ember g ember-cli-foundation-6-sass
 Then, either let the generator add the `app.scss` file, or include the following in your existing one:
 
 ```
-@import 'foundation';
+// For foundation-sites <= 6.3.0
+// @import 'foundation';
+// For foundation-sites >= 6.3.0
 @include foundation-everything;
 ```
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 var path = require('path');
 var fs = require('fs');
 var babel = require('babel-core');
+var semver = require('semver');
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+var BrocDebug = require('broccoli-debug');
 
 module.exports = {
   name: 'ember-cli-foundation-6-sass',
@@ -10,17 +14,37 @@ module.exports = {
     this._super.included(app);
     var options = app.options['ember-cli-foundation-6-sass'];
 
-    var foundationPath = path.join(app.bowerDirectory, 'foundation-sites', 'scss');
+    var foundationPath = path.join(app.bowerDirectory, 'foundation-sites');
+    var foundationVersion = require(path.join(app.project.root, foundationPath, 'bower.json')).version;
+    var isGTE6_3_0 = semver.gte('6.3.0', foundationVersion);
+
     app.options.sassOptions = app.options.sassOptions || {};
     app.options.sassOptions.includePaths = app.options.sassOptions.includePaths || [];
-    app.options.sassOptions.includePaths.push(foundationPath);
+
+    // >=6.3.0 changed some paths.
+    if (isGTE6_3_0) {
+      foundationPath = mergeTrees([new Funnel(foundationPath, {
+        include: ['_vendor/**/*']
+      }), new Funnel(path.join(foundationPath, 'scss'), {
+        destDir: 'foundation-sites',
+        include: ['**/*']
+      })]);
+    }
+
+    app.options.sassOptions.includePaths.push(BrocDebug.instrument.print(foundationPath));
 
     // Include the js paths
     if (options && options.foundationJs) {
-      if ((typeof options.foundationJs == 'string') ||
+      if ((typeof options.foundationJs === 'string') ||
           (options.foundationJs instanceof String)) {
         if (options.foundationJs === 'all') {
-          app.import(path.join(app.bowerDirectory, 'foundation-sites', 'dist', 'js', 'foundation.js'));
+
+          // >=6.3.0 changed some paths.
+          if (isGTE6_3_0) {
+            app.import(path.join(app.bowerDirectory, 'foundation-sites', 'dist', 'js', 'foundation.js'));
+          } else {
+            app.import(path.join(app.bowerDirectory, 'foundation-sites', 'js', 'foundation.js'));
+          }
         }
       }
       else if (options.foundationJs instanceof Array) {

--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@
 var path = require('path');
 var fs = require('fs');
 var babel = require('babel-core');
-var semver = require('semver');
+var VersionChecker = require('ember-cli-version-checker');
 var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
-var BrocDebug = require('broccoli-debug');
 
 module.exports = {
   name: 'ember-cli-foundation-6-sass',
@@ -15,8 +14,8 @@ module.exports = {
     var options = app.options['ember-cli-foundation-6-sass'];
 
     var foundationPath = path.join(app.bowerDirectory, 'foundation-sites');
-    var foundationVersion = require(path.join(app.project.root, foundationPath, 'bower.json')).version;
-    var isGTE6_3_0 = semver.gte('6.3.0', foundationVersion);
+    var checker = new VersionChecker(this);
+    var isGTE6_3_0 = checker.for('foundation-sites', 'bower').satisfies('>=6.3.0');
 
     app.options.sassOptions = app.options.sassOptions || {};
     app.options.sassOptions.includePaths = app.options.sassOptions.includePaths || [];
@@ -31,7 +30,7 @@ module.exports = {
       })]);
     }
 
-    app.options.sassOptions.includePaths.push(BrocDebug.instrument.print(foundationPath));
+    app.options.sassOptions.includePaths.push(foundationPath);
 
     // Include the js paths
     if (options && options.foundationJs) {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "broccoli-merge-trees": "^1.2.1",
     "ember-cli-htmlbars": "^1.0.2",
     "ember-cli-sass": "^5.1.0",
-    "semver": "^5.3.0"
+    "ember-cli-version-checker": "^1.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -57,8 +57,11 @@
     "babel-plugin-transform-es2015-spread": "^6.8.0",
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",
     "babel-register": "^6.18.0",
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^1.2.1",
     "ember-cli-htmlbars": "^1.0.2",
-    "ember-cli-sass": "^5.1.0"
+    "ember-cli-sass": "^5.1.0",
+    "semver": "^5.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,2 +1,5 @@
-@import 'foundation';
+// For foundation-sites <= 6.3.0
+// @import 'foundation';
+// For foundation-sites >= 6.3.0
+@import 'foundation-sites/foundation';
 @include foundation-everything;


### PR DESCRIPTION
Fixes #44.

I'm not sure this is considered a breaking change because loading of foundation in scss/sass is changed.

From:
```sass
@import "foundation";
```

To:
```sass
@import "foundation-sites/foundation";
```

I have yet to update the blueprint and would like some direction there.