### PR TITLE
Update _settings.scss and app.scss with new paths.

### DIFF
--- a/blueprints/ember-cli-foundation-6-sass/index.js
+++ b/blueprints/ember-cli-foundation-6-sass/index.js
@@ -10,7 +10,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   beforeInstall: function () {
-    // return this.addBowerPackageToProject('foundation-sites', bower.dependencies['foundation-sites']);
+    return this.addBowerPackageToProject('foundation-sites', bower.dependencies['foundation-sites']);
   },
 
   afterInstall: function () {

--- a/blueprints/ember-cli-foundation-6-sass/index.js
+++ b/blueprints/ember-cli-foundation-6-sass/index.js
@@ -3,13 +3,14 @@
 var fs          = require('fs');
 var path        = require('path');
 var bower       = require(path.resolve(__dirname, '../../bower.json'));
+var VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   description: 'install ember-cli-foundation-6-sass into a typical project',
   normalizeEntityName: function() {},
 
   beforeInstall: function () {
-    return this.addBowerPackageToProject('foundation-sites', bower.dependencies['foundation-sites']);
+    // return this.addBowerPackageToProject('foundation-sites', bower.dependencies['foundation-sites']);
   },
 
   afterInstall: function () {
@@ -17,12 +18,47 @@ module.exports = {
     var stylePath = path.join(process.cwd(), 'app', 'styles');
     var foundationPath = path.join(process.cwd(), 'bower_components', 'foundation-sites', 'scss');
     var settingsPath = path.join(foundationPath, 'settings', '_settings.scss');
+    var checker = new VersionChecker(this);
+    var isGTE6_3_0 = checker.for('foundation-sites', 'bower').satisfies('>=6.3.0');
+    var settingsFile = fs.readFileSync(settingsPath);
+    var settingsFilePath = path.join(stylePath, '_settings.scss');
+    var appFile, appFilePath;
 
-    fs.writeFileSync(path.join(stylePath, '_settings.scss'), fs.readFileSync(settingsPath));
+    if (isGTE6_3_0) {
+      //edit app.scss to change @import 'foundation'; with @import 'foundation-sites/foundation';
+      appFilePath = path.join(stylePath, 'app.scss');
+      appFile = fs.readFileSync(appFilePath, 'utf-8');
+
+      appFile = appFile.replace('@import \'foundation\';', '@import \'foundation-sites/foundation\';');
+
+      fs.writeFileSync(appFilePath, appFile);
+
+      //edit settingsFile contents to replace @import 'util/util'; with @import 'foundation-sites/util/util';
+      settingsFile = settingsFile.toString('utf-8').replace('@import \'util/util\';', '@import \'foundation-sites/util/util\';');
+
+      this._writeInfoLine('Updated ' + appFilePath + ' with correct foundation import path (see https://github.com/acoustep/ember-cli-foundation-6-sass/issues/40).');
+      this._writeInfoLine('Updated ' + settingsFilePath + ' with correct foundation import path (see https://github.com/acoustep/ember-cli-foundation-6-sass/issues/40).');
+    }
+
+    fs.writeFileSync(settingsFilePath, settingsFile);
 
     return this.addPackagesToProject([
       { name: 'ember-cli-sass', target: '^5.1.0' },
       { name: 'broccoli-clean-css', target: '~1.1.0' }
     ]);
-  }
+  },
+
+  /**
+   A wrapper method to write a message with writeWarnLine or writeLine, depending on which version
+   of ember-cli is used
+
+   @param {string} msg Message to print
+   */
+    _writeInfoLine: function(msg) {
+        if (this.ui.writeWarnLine) {
+            this.ui.writeWarnLine(msg);
+        } else {
+            this.ui.writeLine(msg, 'INFO');
+        }
+    }
 };


### PR DESCRIPTION
Currently, the user will see an error for the first time immediately after running `ember serve` after installing the addon.

This is caused by the blueprint's `app.scss` and the copied `_settings.scss` files having the incorrect paths.

The change involves having the blueprint update the files with the appropriate paths during `afterInstall`.

1. If `foundation-sites` version is >= 6.3.0, then edit the files.
2. Change the path for `foundation` in `app.scss` from `@import 'foundation';` to `@import 'foundation-sites/foundation';`
3. Change path for `util` in `_settings.scss` from `@import 'util/util';` to `@import 'foundation-sites/util/util';`.
4. Inform the user by writing to stdout via UI object, that changes were made to the files.