### PR TITLE
Update to ember-cli-sass@6.0.0.

### DIFF
--- a/blueprints/ember-cli-foundation-6-sass/index.js
+++ b/blueprints/ember-cli-foundation-6-sass/index.js
@@ -21,7 +21,7 @@ module.exports = {
     fs.writeFileSync(path.join(stylePath, '_settings.scss'), fs.readFileSync(settingsPath));
 
     return this.addPackagesToProject([
-      { name: 'ember-cli-sass', target: '^5.1.0' },
+      { name: 'ember-cli-sass', target: '^6.0.0' },
       { name: 'broccoli-clean-css', target: '~1.1.0' }
     ]);
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.2.1",
     "ember-cli-htmlbars": "^1.0.2",
-    "ember-cli-sass": "^5.1.0",
+    "ember-cli-sass": "^6.0.0",
     "ember-cli-version-checker": "^1.2.0"
   },
   "ember-addon": {


### PR DESCRIPTION
I'm not entirely sure why `broccoli-sass-source-maps` wasn't installed by `ember-cli-sass`, but this could help with #43?