### PR TITLE
Move ember-cli-babel to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "broccoli-asset-rev": "^2.2.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -59,6 +58,7 @@
     "babel-register": "^6.18.0",
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.2.1",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.2",
     "ember-cli-sass": "^6.0.0",
     "ember-cli-version-checker": "^1.2.0"


### PR DESCRIPTION
In order to solve the below deprecation warning introduced in Ember *2.12*:
```
DEPRECATION: Addon files were detected in `/Users/melvin/Projects/bazaar/node_modules/ember-cli-foundation-6-sass/addon`, but no JavaScript preprocessors were found for `ember-cli-foundation-6-sass`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-cli-foundation-6-sass`'s `package.json`.
```