### PR TITLE
Remove bower.json from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,5 @@
 .eslintrc.js
 .watchmanconfig
 .travis.yml
-bower.json
 ember-cli-build.js
 testem.js


### PR DESCRIPTION
The installation fails because the blueprint is expecting the bower.json file to be within the npm package. see: https://github.com/acoustep/ember-cli-foundation-6-sass/blob/master/blueprints/ember-cli-foundation-6-sass/index.js#L5