### PR TITLE
Remove bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # dependencies
 /node_modules
-/bower_components
 
 # misc
 /.sass-cache

--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,8 @@
-/bower_components
 /config/ember-try.js
 /dist
 /tests
 /tmp
 **/.gitkeep
-.bowerrc
 .editorconfig
 .ember-cli
 .gitignore

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ To run the sample, clone this repo and run:
 
 ```bash
 npm install
-bower install
 ember serve
 ```
 

--- a/blueprints/ember-cli-foundation-6-sass/index.js
+++ b/blueprints/ember-cli-foundation-6-sass/index.js
@@ -2,7 +2,6 @@
 
 var fs          = require('fs');
 var path        = require('path');
-var bower       = require(path.resolve(__dirname, '../../bower.json'));
 var VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
@@ -10,16 +9,26 @@ module.exports = {
   normalizeEntityName: function() {},
 
   beforeInstall: function () {
-    return this.addBowerPackageToProject('foundation-sites', bower.dependencies['foundation-sites']);
+    return this.addPackageToProject('foundation-sites', "^6.3.1");
   },
 
   afterInstall: function () {
+    // determine what version we are using
+    var checker = new VersionChecker(this);
+    var isGTE6_3_0 = checker.for('foundation-sites', 'npm').satisfies('>=6.3.0');
+
     // Copy the _settings.scss file
     var stylePath = path.join(process.cwd(), 'app', 'styles');
-    var foundationPath = path.join(process.cwd(), 'bower_components', 'foundation-sites', 'scss');
+    // Calculate the path using require.resolve which checks the whole path.
+    // This gives us a specific file in dist/js/npm.js hence the need to path.resolve our way back up.
+    var foundationPath = path.resolve(require.resolve('foundation-sites'), '../../scss/');
+
+    // some thats changed in
+    if (isGTE6_3_0) {
+      foundationPath = path.resolve(require.resolve('foundation-sites'), '../../../scss/');
+    }
+
     var settingsPath = path.join(foundationPath, 'settings', '_settings.scss');
-    var checker = new VersionChecker(this);
-    var isGTE6_3_0 = checker.for('foundation-sites', 'bower').satisfies('>=6.3.0');
     var settingsFile = fs.readFileSync(settingsPath);
     var settingsFilePath = path.join(stylePath, '_settings.scss');
     var appFile, appFilePath;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "ember-cli-foundation-6-sass",
-  "dependencies": {
-    "foundation-sites": "^6.3.1"
-  }
-}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,6 +14,9 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': null
+        },
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
         }
       }
     },
@@ -35,49 +38,34 @@ module.exports = {
     },
     {
       name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
-          'ember': 'release'
-        }
-      },
       npm: {
         devDependencies: {
           'ember-source': null
+        },
+        dependencies: {
+          'ember': 'components/ember#release'
         }
       }
     },
     {
       name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      },
       npm: {
         devDependencies: {
           'ember-source': null
+        },
+        dependencies: {
+          'ember': 'components/ember#beta'
         }
       }
     },
     {
       name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      },
       npm: {
         devDependencies: {
           'ember-source': null
+        },
+        dependencies: {
+          'ember': 'components/ember#canary'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "ember-cli-htmlbars": "^1.0.2",
     "ember-cli-sass": "^6.1.3",
     "ember-cli-version-checker": "^1.3.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.2"
+    "ember-cli-htmlbars-inline-precompile": "^0.4.2",
+    "foundation-sites": "^6.3.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/package.json
+++ b/tests/dummy/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dummy",
+  "version": "0.0.0",
+  "dependencies": {
+
+  }
+}

--- a/tests/integration/components/zf-dropdown-test.js
+++ b/tests/integration/components/zf-dropdown-test.js
@@ -14,7 +14,7 @@ test('it renders', function(assert) {
   // Template block usage:" + EOL +
   this.render(hbs`
     <button class="button" data-toggle="example-dropdown">Toggle Dropdown</button>
-    {{#zf-dropdown id="example-dropdown"}}
+    {{#zf-dropdown id="example-dropdown" positionClass="bottom"}}
       Example form in a dropdown.
       <form>
         <div class="row">

--- a/tests/integration/components/zf-reveal-test.js
+++ b/tests/integration/components/zf-reveal-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -27,21 +28,19 @@ test('it renders', function(assert) {
 });
 
 test('it destroys the reveal-overlay', function(assert) {
-  assert.expect(1);
-
-  this.set('enableReveal', true);
+  assert.expect(2);
 
   this.render(hbs`
-    {{#if enableReveal}}
-      {{#zf-reveal}}
-        template block text
-      {{/zf-reveal}}
-    {{/if}}
+    {{#zf-reveal}}
+      template block text
+    {{/zf-reveal}}
   `);
 
-  //assert.equal(this.$('.reveal').length, 1);
+  assert.equal(Ember.$('.reveal-overlay').length, 1);
 
-  this.set('enableReveal', false);
+  this.render(hbs`
+    Hello World
+  `);
 
-  assert.ok(this.$());
+  assert.equal(Ember.$('.reveal-overlay').length, 0);
 });


### PR DESCRIPTION
Removes the dependancy on bower following its deprecation and uses NPM for everything. This also make the project fully compatible with YARN. 

Closes #70.