### PR TITLE
add production test step to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --environment=production --skip-cleanup
+  - node_modules/.bin/ember test --environment=production
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --environment=production --skip-cleanup


### PR DESCRIPTION
`ember try` does not have a production environment option, so we should add an explicit call to `ember test` in the script step